### PR TITLE
cleaner binning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .project
 .settings
 target
+.idea
+*.iml

--- a/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/AbstractUpdateDiagnosticBinsCallable.java
+++ b/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/AbstractUpdateDiagnosticBinsCallable.java
@@ -44,7 +44,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
     private final List<String> clinVarAssertionStatusExcludes = Arrays.asList("no assertion criteria provided", "no assertion provided",
             "not classified by submitter");
 
-    private final List<String> clinvarLikelyPathogenicAllowableVariantEffects = Arrays.asList("nonsense", "splice-site",
+    private final List<String> likelyPathogenicAllowableVariantEffects = Arrays.asList("nonsense", "splice-site",
             "boundary-crossing indel", "stoploss", "nonsense indel", "frameshifting indel");
 
     private final List<String> possiblyPathogenicAllowableVariantEffects = Arrays.asList("missense", "non-frameshifting indel");
@@ -195,9 +195,6 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         logger.debug("ENTERING findHGMDLikelyPathogenic(Variants_80_4, LocatedVariant)");
         BinResultsFinalDiagnostic binResultsFinalDiagnostic = null;
 
-        List<String> allowableVariantEffects = Arrays.asList("nonsense", "splice-site", "boundary-crossing indel", "stoploss",
-                "nonsense indel", "frameshifting indel");
-
         DiseaseClass diseaseClass = allDiseaseClasses.stream().filter(a -> a.getId().equals(2)).findAny().get();
 
         List<HGMDLocatedVariant> hgmdLocatedVariantList = daoBean.getHGMDLocatedVariantDAO()
@@ -222,7 +219,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
             return null;
         }
 
-        if (allowableVariantEffects.contains(variant.getVariantEffect().getId())) {
+        if (likelyPathogenicAllowableVariantEffects.contains(variant.getVariantEffect().getId())) {
 
             SNPMappingAgg snpMappingAgg = daoBean.getSNPMappingAggDAO().findById(new SNPMappingAggPK(locatedVariant37.getId()));
 
@@ -275,7 +272,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
             return null;
         }
 
-        if (clinvarLikelyPathogenicAllowableVariantEffects.contains(variant.getVariantEffect().getId())) {
+        if (likelyPathogenicAllowableVariantEffects.contains(variant.getVariantEffect().getId())) {
 
             SNPMappingAgg snpMappingAgg = daoBean.getSNPMappingAggDAO().findById(new SNPMappingAggPK(locatedVariant37.getId()));
 

--- a/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/AbstractUpdateDiagnosticBinsCallable.java
+++ b/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/AbstractUpdateDiagnosticBinsCallable.java
@@ -49,7 +49,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
 
     private final List<String> possiblyPathogenicAllowableVariantEffects = Arrays.asList("missense", "non-frameshifting indel");
 
-    private final List<String> uncertainSignificanceAllowableLocationTypes = Arrays.asList("UTR-5", "UTR-3", "UTR");
+    private final List<String> uncertainSignificanceAllowableLocationTypes = Arrays.asList("UTR-5", "UTR-3", "UTR", "exon", "intron/exon boundary");
 
     private final List<String> uncertainSignificanceAllowableVariantEffects = Arrays.asList("synonymous", "synonymous indel", "intron",
             "splice-site-UTR-3", "splice-site-UTR-5", "splice-site-UTR", "potential RNA-editing site", "noncoding boundary-crossing indel");
@@ -74,6 +74,155 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         }
     }
 
+    private BinResultsFinalDiagnostic makeProvisionalBinResults(Variants_80_4 variant, LocatedVariant locatedVariant37,
+                                                                MaxFrequency maxFrequency, DiagnosticGene diagnosticGene)
+            throws CANVASDAOException {
+        SNPMappingAgg snpMappingAgg = daoBean.getSNPMappingAggDAO().findById(new SNPMappingAggPK(locatedVariant37.getId()));
+
+        NCGenesFrequencies ncgenesFrequencies = daoBean.getNCGenesFrequenciesDAO()
+                .findById(new NCGenesFrequenciesPK(locatedVariant37.getId(), maxNCGenesFrequenciesVersion.toString()));
+
+        AssemblyLocatedVariant assemblyLocatedVariant = daoBean.getAssemblyLocatedVariantDAO().findById(
+                new AssemblyLocatedVariantPK(diagnosticBinningJob.getAssembly().getId(), variant.getLocatedVariant().getId()));
+
+        AssemblyLocatedVariantQC assemblyLocatedVariantQC = daoBean.getAssemblyLocatedVariantQCDAO().findById(
+                new AssemblyLocatedVariantQCPK(diagnosticBinningJob.getAssembly().getId(), variant.getLocatedVariant().getId()));
+
+        UnimportantExon unimportantExon = daoBean.getUnimportantExonDAO()
+                .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
+
+        return BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
+                diagnosticGene, maxFrequency, snpMappingAgg, ncgenesFrequencies,
+                assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
+
+    }
+
+    private int calculateProvisionalClass(Variants_80_4 variant, MaxFrequency maxFrequency) throws CANVASDAOException {
+
+        if (maxFrequency.getMaxAlleleFreq() < 0.01) {
+            // class B
+            if (likelyPathogenicAllowableVariantEffects.contains(variant.getVariantEffect().getId())) {
+                return 2;
+            }
+            // class C
+            if (possiblyPathogenicAllowableVariantEffects.contains(variant.getVariantEffect().getId())) {
+                return 3;
+            }
+            if (uncertainSignificanceAllowableVariantEffects.contains(variant.getVariantEffect().getId())
+                    || uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId())) {
+                return 4;
+            }
+        } else if (maxFrequency.getMaxAlleleFreq() >= 0.01 && maxFrequency.getMaxAlleleFreq() < 0.05
+                && uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId())) {
+            return 4;
+        }
+
+        if (maxFrequency.getMaxAlleleFreq() >= 0.1 && uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId())) {
+            return 5;
+        }
+
+        if (maxFrequency.getMaxAlleleFreq() >= 0.05 && !uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId())) {
+            return 5;
+        }
+        return 6;
+    }
+
+    public BinResultsFinalDiagnostic binVariantClinVar(Variants_80_4 variant, LocatedVariant locatedVariant37,
+                                                       MaxFrequency maxFrequency, DiagnosticGene diagnosticGene
+                                                    ) throws CANVASDAOException {
+        int variantClass = calculateProvisionalClass(variant, maxFrequency);
+
+        DiagnosticResultVersion diagnosticResultVersion = diagnosticBinningJob.getDiagnosticResultVersion();
+
+        ReferenceClinicalAssertion rca = null;
+        List<ReferenceClinicalAssertion> foundReferenceClinicalAssersions = daoBean.getReferenceClinicalAssertionDAO()
+                .findByLocatedVariantIdAndVersionAndAssertionStatusExclusionList(locatedVariant37.getId(),
+                        diagnosticResultVersion.getClinvarVersion().getId(), clinVarAssertionStatusExcludes);
+
+        if (CollectionUtils.isNotEmpty(foundReferenceClinicalAssersions)) {
+
+            boolean containsValidAssertionRanking = foundReferenceClinicalAssersions.stream()
+                    .anyMatch((s) -> knownPathogenicClinVarAssertionRankings.contains(s.getAssertion().getRank()));
+
+            if (containsValidAssertionRanking) {
+                foundReferenceClinicalAssersions.sort((a, b) -> a.getAssertion().getRank().compareTo(b.getAssertion().getRank()));
+                rca = foundReferenceClinicalAssersions.get(0);
+                logger.debug(rca.toString());
+                if (StringUtils.isEmpty(rca.getExplanation()) || StringUtils.containsIgnoreCase(rca.getExplanation(), "pathogenic")) {
+                    if (CollectionUtils.isNotEmpty(rca.getSubmissionClinicalAssertions())) {
+
+                        Optional<SubmissionClinicalAssertion> optionalSubmissionClinicalAssertion = rca.getSubmissionClinicalAssertions().stream()
+                                .filter(a -> StringUtils.containsIgnoreCase(a.getAssertion(), "pathogenic")).findAny();
+                        if (optionalSubmissionClinicalAssertion.isPresent()) {
+                            optionalSubmissionClinicalAssertion = rca.getSubmissionClinicalAssertions().stream()
+                                    .filter(a -> StringUtils.containsIgnoreCase(a.getAssertion(), "pathogenic")
+                                            && StringUtils.containsIgnoreCase(a.getReviewStatus(), "no assertion"))
+                                    .findAny();
+                            if (optionalSubmissionClinicalAssertion.isPresent()) {
+                                // We found a match!
+                                variantClass = 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        BinResultsFinalDiagnostic binResultsFinalDiagnostic = makeProvisionalBinResults(variant, locatedVariant37, maxFrequency, diagnosticGene);
+
+        int finalVariantClass = variantClass;
+        DiseaseClass diseaseClass = allDiseaseClasses.stream().filter(a -> a.getId().equals(finalVariantClass)).findAny().get();
+
+        binResultsFinalDiagnostic.setClinvarDiseaseClass(diseaseClass);
+
+        if (rca != null) {
+            binResultsFinalDiagnostic.setClinvarAccession(rca.getAccession());
+            binResultsFinalDiagnostic.setClinvarAssertion(rca.getAssertion());
+        }
+
+        return binResultsFinalDiagnostic;
+
+    }
+
+    public BinResultsFinalDiagnostic binVariantHGMD(Variants_80_4 variant, LocatedVariant locatedVariant37,
+                                                    MaxFrequency maxFrequency, DiagnosticGene diagnosticGene
+                            ) throws CANVASDAOException {
+        int variantClass = calculateProvisionalClass(variant, maxFrequency);
+
+        HGMDLocatedVariant hgmdLocatedVariant = null;
+        List<HGMDLocatedVariant> hgmdLocatedVariantList = daoBean.getHGMDLocatedVariantDAO()
+                .findByLocatedVariantId(locatedVariant37.getId());
+
+        if (CollectionUtils.isNotEmpty(hgmdLocatedVariantList)) {
+
+            Optional<HGMDLocatedVariant> optionalHGMDLocatedVariant = hgmdLocatedVariantList.stream()
+                    .filter((s) -> s.getId().getVersion().equals(2) && s.getTag().equals("DM")).findAny();
+
+            if (optionalHGMDLocatedVariant.isPresent()) {
+                // found a match!
+                hgmdLocatedVariant = optionalHGMDLocatedVariant.get();
+                variantClass = 1;
+            }
+
+        }
+
+        BinResultsFinalDiagnostic binResultsFinalDiagnostic = makeProvisionalBinResults(variant, locatedVariant37, maxFrequency, diagnosticGene);
+
+        int finalVariantClass = variantClass;
+        DiseaseClass diseaseClass = allDiseaseClasses.stream().filter(a -> a.getId().equals(finalVariantClass)).findAny().get();
+
+        binResultsFinalDiagnostic.setHgmdDiseaseClass(diseaseClass);
+
+        if (hgmdLocatedVariant != null) {
+            binResultsFinalDiagnostic.setHgmdAccessionNumber(hgmdLocatedVariant.getId().getAccession());
+            binResultsFinalDiagnostic.setHgmdTag(hgmdLocatedVariant.getTag());
+        }
+
+        return binResultsFinalDiagnostic;
+
+    }
+
+    @Deprecated
     public BinResultsFinalDiagnostic findHGMDKnownPathogenic(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findHGMDKnownPathogenic(Variants_80_4, LocatedVariant)");
@@ -119,6 +268,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findClinVarKnownPathogenic(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findClinVarKnownPathogenic(Variants_80_4, LocatedVariant)");
@@ -190,6 +340,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
 
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findHGMDLikelyPathogenic(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findHGMDLikelyPathogenic(Variants_80_4, LocatedVariant)");
@@ -215,11 +366,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
             }
         }
 
-        if (maxFrequency.getMaxAlleleFreq() >= 0.01) {
-            return null;
-        }
-
-        if (likelyPathogenicAllowableVariantEffects.contains(variant.getVariantEffect().getId())) {
+        if (maxFrequency.getMaxAlleleFreq() < 0.01 && likelyPathogenicAllowableVariantEffects.contains(variant.getVariantEffect().getId())) {
 
             SNPMappingAgg snpMappingAgg = daoBean.getSNPMappingAggDAO().findById(new SNPMappingAggPK(locatedVariant37.getId()));
 
@@ -243,6 +390,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findClinVarLikelyPathogenic(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findClinVarLikelyPathogenic(Variants_80_4, LocatedVariant)");
@@ -297,6 +445,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findHGMDPossiblyPathogenic(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findKnownPathogenic(Variants_80_4, LocatedVariant)");
@@ -347,6 +496,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findClinVarPossiblyPathogenic(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findKnownPathogenic(Variants_80_4, LocatedVariant)");
@@ -395,6 +545,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findHGMDUncertainSignificance(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findHGMDUncertainSignificance(Variants_80_4, LocatedVariant)");
@@ -457,6 +608,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findClinVarUncertainSignificance(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findClinVarUncertainSignificance(Variants_80_4, LocatedVariant)");
@@ -525,14 +677,13 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findHGMDLikelyBenign(Variants_80_4 variant, LocatedVariant locatedVariant37, MaxFrequency maxFrequency,
             DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findHGMDLikelyBenign(Variants_80_4, LocatedVariant)");
         BinResultsFinalDiagnostic binResultsFinalDiagnostic = null;
 
         try {
-            List<String> allowableLocationTypes = Arrays.asList("UTR-5", "UTR-3", "UTR", "exon", "intron/exon boundary");
-
             DiseaseClass diseaseClass = allDiseaseClasses.stream().filter(a -> a.getId().equals(5)).findAny().get();
 
             List<HGMDLocatedVariant> hgmdLocatedVariantList = daoBean.getHGMDLocatedVariantDAO()
@@ -571,7 +722,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
             if (maxFrequency.getMaxAlleleFreq() >= 0.05 && maxFrequency.getMaxAlleleFreq() < 0.1
-                    && allowableLocationTypes.contains(variant.getLocationType().getId())) {
+                    && uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
                         diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
@@ -580,7 +731,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
             }
 
             if (binResultsFinalDiagnostic == null && maxFrequency.getMaxAlleleFreq() < 0.05
-                    && !allowableLocationTypes.contains(variant.getLocationType().getId())) {
+                    && !uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
                         diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant,  snpMappingAgg,
@@ -594,6 +745,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findClinVarLikelyBenign(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findClinVarLikelyBenign(Variants_80_4, LocatedVariant)");
@@ -663,6 +815,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findHGMDAlmostCertainlyBenign(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findHGMDAlmostCertainlyBenign(Variants_80_4, LocatedVariant, MaxFrequency, DiagnosticGene)");
@@ -731,6 +884,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
         return binResultsFinalDiagnostic;
     }
 
+    @Deprecated
     public BinResultsFinalDiagnostic findClinVarAlmostCertainlyBenign(Variants_80_4 variant, LocatedVariant locatedVariant37,
             MaxFrequency maxFrequency, DiagnosticGene diagnosticGene) throws CANVASDAOException {
         logger.debug("ENTERING findClinVarAlmostCertainlyBenign(Variants_80_4, LocatedVariant)");

--- a/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/AbstractUpdateDiagnosticBinsCallable.java
+++ b/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/AbstractUpdateDiagnosticBinsCallable.java
@@ -109,7 +109,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                         .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
                         ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -181,7 +181,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                    diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                     assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -239,7 +239,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
                     ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -292,7 +292,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                    diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                     assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -343,7 +343,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
                     ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -391,7 +391,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                    diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                     assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -441,7 +441,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                         || uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId()))) {
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
                     ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -453,7 +453,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                 && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
                     ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -505,7 +505,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                             || uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId()))) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -517,7 +517,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -577,7 +577,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
                         ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -586,7 +586,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     && !allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant,  snpMappingAgg,
                         ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -647,7 +647,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -656,7 +656,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     && !allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -714,7 +714,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
             if (maxFrequency.getMaxAlleleFreq() >= 0.1 && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
                         ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -723,7 +723,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     && (maxFrequency.getMaxAlleleFreq() >= 0.05 && !allowableLocationTypes.contains(variant.getLocationType().getId()))) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, snpMappingAgg,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, snpMappingAgg,
                         ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -783,7 +783,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
             if (maxFrequency.getMaxAlleleFreq() >= 0.1 && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -792,7 +792,7 @@ public abstract class AbstractUpdateDiagnosticBinsCallable implements Callable<V
                     && !allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }

--- a/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/BinResultsFinalDiagnosticFactory.java
+++ b/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/BinResultsFinalDiagnosticFactory.java
@@ -25,14 +25,11 @@ public class BinResultsFinalDiagnosticFactory {
     private static final Logger logger = LoggerFactory.getLogger(BinResultsFinalDiagnosticFactory.class);
 
     public static BinResultsFinalDiagnostic createBinResultsFinalDiagnostic(DiagnosticBinningJob diagnosticBinningJob,
-            Variants_80_4 variant, DiseaseClass clinvarDiseaseClass, DiagnosticGene diagnosticGene, MaxFrequency maxFrequency,
-            ReferenceClinicalAssertion rca, Integer maxNCGenesFrequenciesVersion, SNPMappingAgg snpMappingAgg,
-            NCGenesFrequencies ncgenesFrequencies, AssemblyLocatedVariant assemblyLocatedVariant,
-            AssemblyLocatedVariantQC assemblyLocatedVariantQC, UnimportantExon unimportantExon) throws CANVASDAOException {
-        logger.debug(
-                "ENTERING createBinResultsFinalDiagnostic(DiagnosticBinningJob, Variants_80_4, DiseaseClass, DiagnosticGene, MaxFrequency, ReferenceClinicalAssertion, Integer, SNPMappingAgg)");
-
-        BinResultsFinalDiagnostic binResultsFinalDiagnostic = null;
+                                                                            Variants_80_4 variant, DiagnosticGene diagnosticGene,
+                                                                            MaxFrequency maxFrequency, SNPMappingAgg snpMappingAgg,
+                                                                            NCGenesFrequencies ncgenesFrequencies, AssemblyLocatedVariant assemblyLocatedVariant,
+                                                                            AssemblyLocatedVariantQC assemblyLocatedVariantQC, UnimportantExon unimportantExon) {
+        BinResultsFinalDiagnostic binResultsFinalDiagnostic = new BinResultsFinalDiagnostic();
         try {
 
             DiagnosticResultVersion diagnosticResultVersion = diagnosticBinningJob.getDiagnosticResultVersion();
@@ -49,7 +46,6 @@ public class BinResultsFinalDiagnosticFactory {
             binResultsFinalDiagnostic.setDiagnosticResultVersion(diagnosticResultVersion);
             binResultsFinalDiagnostic.setDx(dx);
             binResultsFinalDiagnostic.setVariantEffect(variant.getVariantEffect());
-            binResultsFinalDiagnostic.setClinvarDiseaseClass(clinvarDiseaseClass);
 
             // variant stuff
             binResultsFinalDiagnostic.setChromosome(variant.getId().getGenomeRefSeq());
@@ -77,11 +73,6 @@ public class BinResultsFinalDiagnosticFactory {
             binResultsFinalDiagnostic.setTranscriptPosition(variant.getTranscriptPosition());
             binResultsFinalDiagnostic.setType(variant.getVariantType().getId());
             binResultsFinalDiagnostic.setVariantEffect(variant.getVariantEffect());
-
-            if (rca != null) {
-                binResultsFinalDiagnostic.setClinvarAccession(rca.getAccession());
-                binResultsFinalDiagnostic.setClinvarAssertion(rca.getAssertion());
-            }
 
             if (assemblyLocatedVariant != null) {
                 binResultsFinalDiagnostic.setHomozygous(assemblyLocatedVariant.getHomozygous());
@@ -122,115 +113,52 @@ public class BinResultsFinalDiagnosticFactory {
 
             binResultsFinalDiagnostic.setExonTruncationCount(
                     (unimportantExon != null && unimportantExon.getCount() != null) ? unimportantExon.getCount() : 0);
+
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
         }
+        return binResultsFinalDiagnostic;
+    }
+
+    // ClinVar
+    public static BinResultsFinalDiagnostic createBinResultsFinalDiagnostic(DiagnosticBinningJob diagnosticBinningJob,
+                                                                            Variants_80_4 variant, DiseaseClass clinvarDiseaseClass, DiagnosticGene diagnosticGene, MaxFrequency maxFrequency,
+                                                                            ReferenceClinicalAssertion rca, SNPMappingAgg snpMappingAgg,
+                                                                            NCGenesFrequencies ncgenesFrequencies, AssemblyLocatedVariant assemblyLocatedVariant,
+                                                                            AssemblyLocatedVariantQC assemblyLocatedVariantQC, UnimportantExon unimportantExon) throws CANVASDAOException {
+        logger.debug(
+                "ENTERING createBinResultsFinalDiagnostic(DiagnosticBinningJob, Variants_80_4, DiseaseClass, DiagnosticGene, MaxFrequency, ReferenceClinicalAssertion, Integer, SNPMappingAgg)");
+
+        BinResultsFinalDiagnostic binResultsFinalDiagnostic = createBinResultsFinalDiagnostic(diagnosticBinningJob, variant, diagnosticGene, maxFrequency, snpMappingAgg, ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
+
+        if (rca != null) {
+            binResultsFinalDiagnostic.setClinvarAccession(rca.getAccession());
+            binResultsFinalDiagnostic.setClinvarAssertion(rca.getAssertion());
+        }
+
+        binResultsFinalDiagnostic.setClinvarDiseaseClass(clinvarDiseaseClass);
 
         return binResultsFinalDiagnostic;
     }
 
+
     // hgmd
     public static BinResultsFinalDiagnostic createBinResultsFinalDiagnostic(DiagnosticBinningJob diagnosticBinningJob,
-            Variants_80_4 variant, DiseaseClass hgmdDiseaseClass, DiagnosticGene diagnosticGene, MaxFrequency maxFrequency,
-            HGMDLocatedVariant hgmdLocatedVariant, Integer maxNCGenesFrequenciesVersion, SNPMappingAgg snpMappingAgg,
-            NCGenesFrequencies ncgenesFrequencies, AssemblyLocatedVariant assemblyLocatedVariant,
-            AssemblyLocatedVariantQC assemblyLocatedVariantQC, UnimportantExon unimportantExon) throws CANVASDAOException {
+                                                                            Variants_80_4 variant, DiseaseClass hgmdDiseaseClass, DiagnosticGene diagnosticGene, MaxFrequency maxFrequency,
+                                                                            HGMDLocatedVariant hgmdLocatedVariant, SNPMappingAgg snpMappingAgg,
+                                                                            NCGenesFrequencies ncgenesFrequencies, AssemblyLocatedVariant assemblyLocatedVariant,
+                                                                            AssemblyLocatedVariantQC assemblyLocatedVariantQC, UnimportantExon unimportantExon) throws CANVASDAOException {
         logger.debug(
                 "ENTERING createBinResultsFinalDiagnostic(DiagnosticBinningJob, Variants_80_4, DiseaseClass, DiagnosticGene, MaxFrequency, HGMDLocatedVariant, Integer, SNPMappingAgg)");
 
-        BinResultsFinalDiagnostic binResultsFinalDiagnostic = null;
-        try {
+        BinResultsFinalDiagnostic binResultsFinalDiagnostic = createBinResultsFinalDiagnostic(diagnosticBinningJob, variant, diagnosticGene, maxFrequency, snpMappingAgg, ncgenesFrequencies, assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
-            DiagnosticResultVersion diagnosticResultVersion = diagnosticBinningJob.getDiagnosticResultVersion();
-            DX dx = diagnosticBinningJob.getDx();
-
-            BinResultsFinalDiagnosticPK binResultsFinalDiagnosticPK = new BinResultsFinalDiagnosticPK(diagnosticBinningJob.getParticipant(),
-                    diagnosticResultVersion.getId(), dx.getId(), diagnosticBinningJob.getAssembly().getId(),
-                    variant.getLocatedVariant().getId(), variant.getId().getMapNumber(), variant.getId().getTranscript());
-
-            binResultsFinalDiagnostic = new BinResultsFinalDiagnostic(binResultsFinalDiagnosticPK);
-            binResultsFinalDiagnostic.setLocatedVariant(variant.getLocatedVariant());
-            binResultsFinalDiagnostic.setAssembly(diagnosticBinningJob.getAssembly());
-            binResultsFinalDiagnostic.setLocationType(variant.getLocationType());
-            binResultsFinalDiagnostic.setDiagnosticResultVersion(diagnosticResultVersion);
-            binResultsFinalDiagnostic.setDx(dx);
-            binResultsFinalDiagnostic.setVariantEffect(variant.getVariantEffect());
-            binResultsFinalDiagnostic.setHgmdDiseaseClass(hgmdDiseaseClass);
-
-            // variant stuff
-            binResultsFinalDiagnostic.setChromosome(variant.getId().getGenomeRefSeq());
-            binResultsFinalDiagnostic.setAlternateAllele(variant.getAlternateAllele());
-            binResultsFinalDiagnostic.setAminoAcidStart(variant.getAminoAcidStart());
-            binResultsFinalDiagnostic.setAminoAcidEnd(variant.getAminoAcidEnd());
-            binResultsFinalDiagnostic.setCodingSequencePosition(variant.getCodingSequencePosition());
-            binResultsFinalDiagnostic.setFinalAminoAcid(variant.getFinalAminoAcid());
-            binResultsFinalDiagnostic.setFrameshift(variant.getFrameshift());
-            binResultsFinalDiagnostic.setGeneId(variant.getGene().getId());
-            binResultsFinalDiagnostic.setHgncGene(variant.getHgncGene());
-            binResultsFinalDiagnostic.setHgvsCodingSequence(variant.getHgvsCodingSequence());
-            binResultsFinalDiagnostic.setHgvsGenomic(variant.getHgvsGenomic());
-            binResultsFinalDiagnostic.setHgvsProtein(variant.getHgvsProtein());
-            binResultsFinalDiagnostic.setHgvsTranscript(variant.getHgvsTranscript());
-            binResultsFinalDiagnostic.setInframe(variant.getInframe());
-            binResultsFinalDiagnostic.setIntronExonDistance(variant.getIntronExonDistance());
-            binResultsFinalDiagnostic.setLocationType(variant.getLocationType());
-            binResultsFinalDiagnostic.setNummaps(variant.getNumberOfTranscriptMaps());
-            binResultsFinalDiagnostic.setOriginalAminoAcid(variant.getOriginalAminoAcid());
-            binResultsFinalDiagnostic.setStrand(variant.getStrand());
-            binResultsFinalDiagnostic.setPosition(variant.getId().getPosition());
-            binResultsFinalDiagnostic.setReferenceAllele(variant.getReferenceAllele());
-            binResultsFinalDiagnostic.setRefseqGene(variant.getRefSeqGene());
-            binResultsFinalDiagnostic.setTranscriptPosition(variant.getTranscriptPosition());
-            binResultsFinalDiagnostic.setType(variant.getVariantType().getId());
-            binResultsFinalDiagnostic.setVariantEffect(variant.getVariantEffect());
-
-            if (hgmdLocatedVariant != null) {
-                binResultsFinalDiagnostic.setHgmdAccessionNumber(hgmdLocatedVariant.getId().getAccession());
-                binResultsFinalDiagnostic.setHgmdTag(hgmdLocatedVariant.getTag());
-            }
-
-            if (assemblyLocatedVariant != null) {
-                binResultsFinalDiagnostic.setHomozygous(assemblyLocatedVariant.getHomozygous());
-                binResultsFinalDiagnostic.setGenotypeQual(assemblyLocatedVariant.getGenotypeQuality());
-            }
-
-            if (assemblyLocatedVariantQC != null) {
-                binResultsFinalDiagnostic.setAltDepth(assemblyLocatedVariantQC.getAltDepth());
-                binResultsFinalDiagnostic.setRefDepth(assemblyLocatedVariantQC.getRefDepth());
-                binResultsFinalDiagnostic.setDepth(assemblyLocatedVariantQC.getDepth());
-                binResultsFinalDiagnostic.setFracReadsWithDels(assemblyLocatedVariantQC.getFracReadsWithDels());
-                binResultsFinalDiagnostic.setHrun(assemblyLocatedVariantQC.getHomopolymerRun());
-                binResultsFinalDiagnostic.setGenotypeQual(assemblyLocatedVariantQC.getQualityByDepth());
-                binResultsFinalDiagnostic.setStrandScore(assemblyLocatedVariantQC.getStrandScore());
-                binResultsFinalDiagnostic.setReadPosRankSum(assemblyLocatedVariantQC.getReadPosRankSum());
-                binResultsFinalDiagnostic.setQd(assemblyLocatedVariantQC.getQualityByDepth());
-            }
-
-            if (maxFrequency != null) {
-                binResultsFinalDiagnostic.setMaxAlleleFrequency(maxFrequency.getMaxAlleleFreq());
-            }
-
-            if (diagnosticGene != null) {
-                binResultsFinalDiagnostic.setTier(diagnosticGene.getTier());
-                binResultsFinalDiagnostic.setInheritance(diagnosticGene.getInheritance());
-            }
-
-            if (snpMappingAgg != null) {
-                binResultsFinalDiagnostic.setRsId(snpMappingAgg.getRsIds());
-            }
-
-            binResultsFinalDiagnostic
-                    .setNCGenesAlternateFrequency((ncgenesFrequencies != null && ncgenesFrequencies.getAltAlleleFrequency() != null)
-                            ? ncgenesFrequencies.getAltAlleleFrequency() : 0D);
-
-            binResultsFinalDiagnostic.setNCGenesHWEP(
-                    (ncgenesFrequencies != null && ncgenesFrequencies.getHweP() != null) ? ncgenesFrequencies.getHweP() : 1D);
-
-            binResultsFinalDiagnostic.setExonTruncationCount(
-                    (unimportantExon != null && unimportantExon.getCount() != null) ? unimportantExon.getCount() : 0);
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+        if (hgmdLocatedVariant != null) {
+            binResultsFinalDiagnostic.setHgmdAccessionNumber(hgmdLocatedVariant.getId().getAccession());
+            binResultsFinalDiagnostic.setHgmdTag(hgmdLocatedVariant.getTag());
         }
+
+        binResultsFinalDiagnostic.setHgmdDiseaseClass(hgmdDiseaseClass);
 
         return binResultsFinalDiagnostic;
     }

--- a/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/BinResultsFinalDiagnosticFactory.java
+++ b/binning-core/src/main/java/org/renci/canvas/binning/core/grch38/BinResultsFinalDiagnosticFactory.java
@@ -203,6 +203,7 @@ public class BinResultsFinalDiagnosticFactory {
                 binResultsFinalDiagnostic.setGenotypeQual(assemblyLocatedVariantQC.getQualityByDepth());
                 binResultsFinalDiagnostic.setStrandScore(assemblyLocatedVariantQC.getStrandScore());
                 binResultsFinalDiagnostic.setReadPosRankSum(assemblyLocatedVariantQC.getReadPosRankSum());
+                binResultsFinalDiagnostic.setQd(assemblyLocatedVariantQC.getQualityByDepth());
             }
 
             if (maxFrequency != null) {

--- a/binning-core/src/test/java/org/renci/binning/core/UpdateDiagnosticBinsCallable38Test.java
+++ b/binning-core/src/test/java/org/renci/binning/core/UpdateDiagnosticBinsCallable38Test.java
@@ -412,7 +412,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                         || uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId()))) {
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null, null,
+                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null, null,
                     null);
 
         }
@@ -424,7 +424,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                 && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null, null,
+                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null, null,
                     null);
 
         }
@@ -453,7 +453,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                 logger.debug(hgmdLocatedVariant.toString());
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null,
                         null, null);
 
             }
@@ -503,7 +503,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                         .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -560,7 +560,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                    diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                     assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -610,7 +610,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     .findById(new UnimportantExonPK(variant.getId().getTranscript(), variant.getNonCanonicalExon()));
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                    diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                     assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
         }
@@ -668,7 +668,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                             || uncertainSignificanceAllowableLocationTypes.contains(variant.getLocationType().getId()))) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -680,7 +680,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -743,7 +743,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -752,7 +752,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     && !allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -813,7 +813,7 @@ public class UpdateDiagnosticBinsCallable38Test {
             if (maxFrequency.getMaxAlleleFreq() >= 0.1 && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -822,7 +822,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     && !allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, rca, maxNCGenesFrequenciesVersion, snpMappingAgg, ncgenesFrequencies,
+                        diseaseClass, diagnosticGene, maxFrequency, rca, snpMappingAgg, ncgenesFrequencies,
                         assemblyLocatedVariant, assemblyLocatedVariantQC, unimportantExon);
 
             }
@@ -868,7 +868,7 @@ public class UpdateDiagnosticBinsCallable38Test {
         if (allowableVariantEffects.contains(variant.getVariantEffect().getId())) {
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null, null,
+                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null, null,
                     null);
 
         }
@@ -907,7 +907,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                 && possiblyPathogenicAllowableVariantEffects.contains(variant.getVariantEffect().getId())) {
 
             binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null, null,
+                    diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null, null,
                     null);
 
         }
@@ -950,7 +950,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null,
                         null, null);
 
             }
@@ -959,7 +959,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     && !allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null,
                         null, null);
 
             }
@@ -1005,7 +1005,7 @@ public class UpdateDiagnosticBinsCallable38Test {
             if (maxFrequency.getMaxAlleleFreq() >= 0.1 && allowableLocationTypes.contains(variant.getLocationType().getId())) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null,
                         null, null);
 
             }
@@ -1014,7 +1014,7 @@ public class UpdateDiagnosticBinsCallable38Test {
                     && (maxFrequency.getMaxAlleleFreq() >= 0.05 && !allowableLocationTypes.contains(variant.getLocationType().getId()))) {
 
                 binResultsFinalDiagnostic = BinResultsFinalDiagnosticFactory.createBinResultsFinalDiagnostic(diagnosticBinningJob, variant,
-                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, maxNCGenesFrequenciesVersion, null, null, null,
+                        diseaseClass, diagnosticGene, maxFrequency, hgmdLocatedVariant, null, null, null,
                         null, null);
 
             }


### PR DESCRIPTION
Removes a lot of redundancy in the binning code. The old methods are still there, just deprecated. They should be moved if this works the way I think it does.